### PR TITLE
Add theme `Default-Serif`

### DIFF
--- a/src/assets/themes.json
+++ b/src/assets/themes.json
@@ -187,5 +187,21 @@
       "url": "https://criphc.com"
     },
     "themeInstallUrl": "https://github.com/criphc/nnw-theme/raw/main/red-nnw-theme.nnwtheme.zip"
+  },
+  {
+    "id": "default-serif",
+    "themeTitle": "Default Serif",
+    "themeDescription": "The default NetNewsWire theme, but with Apple's default serif typeface New York.",
+    "pubDate": "2024-11-15T04:56:54.479Z",
+    "themeThumbs": [
+      "https://raw.githubusercontent.com/mischreiber/nnw-themes/refs/tags/v0.1/images/Default-Serif-light.png",
+      "https://raw.githubusercontent.com/mischreiber/nnw-themes/refs/tags/v0.1/images/Default-Serif-dark.png"
+    ],
+    "themeRepo": "https://github.com/mischreiber/nnw-themes#default-serif",
+    "themeAuthor": {
+      "name": "Mike Schreiber",
+      "url": "https://mikeschreiber.me"
+    },
+    "themeInstallUrl": "https://github.com/mischreiber/nnw-themes/releases/download/v0.1/Default-Serif.nnwtheme.zip"
   }
 ]


### PR DESCRIPTION
Adding a new theme: `Default-Serif`

## Default-Serif
The default NetNewsWire theme, but with Apple's default serif typeface New York.

| Light | Dark |
|-----|-----|
| ![light](https://raw.githubusercontent.com/mischreiber/nnw-themes/refs/tags/v0.1/images/Default-Serif-light.png) | ![dark](https://raw.githubusercontent.com/mischreiber/nnw-themes/refs/tags/v0.1/images/Default-Serif-dark.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new theme, "Default Serif," featuring Apple's default serif typeface.
	- Added thumbnail images for both light and dark versions of the theme.
	- Provided links for theme repository and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->